### PR TITLE
Krew manifest update for kcp version v0.27.0

### DIFF
--- a/plugins/create-workspace.yaml
+++ b/plugins/create-workspace.yaml
@@ -4,46 +4,46 @@ kind: Plugin
 metadata:
   name: create-workspace
 spec:
-  version: v0.26.1
+  version: v0.27.0
   platforms:
     - bin: bin/kubectl-create-workspace.exe
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-create-workspace-plugin_0.26.1_windows_arm64.tar.gz
-      sha256: 3447997377a353e2f2beae7b98bc306567eb8759e37582af670d50c02687fd68
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-create-workspace-plugin_0.27.0_windows_arm64.tar.gz
+      sha256: 5ec579af4ba8004988f021b756f2920a89ec4ba536bf299d21e3a14a7441890e
       selector:
         matchLabels:
           os: windows
           arch: arm64
     - bin: bin/kubectl-create-workspace.exe
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-create-workspace-plugin_0.26.1_windows_amd64.tar.gz
-      sha256: d976e96394672ea42d9a9ccba1883415544a4a9247ca350f300ce4648f71bf31
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-create-workspace-plugin_0.27.0_windows_amd64.tar.gz
+      sha256: 20c8cc6e978a1c0e983cf8684be340427aa9e81ea490b91ae1ef9bbd4bb9750c
       selector:
         matchLabels:
           os: windows
           arch: amd64
     - bin: bin/kubectl-create-workspace
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-create-workspace-plugin_0.26.1_linux_arm64.tar.gz
-      sha256: 132bfc71d3872b9bc2489af5146642b1d7fae0918e7b62894f6dce85ff3ea287
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-create-workspace-plugin_0.27.0_linux_arm64.tar.gz
+      sha256: 497f3fd8a93c6170045df934a461e1dbd6ea5b843d5eba0307db4db789fe100a
       selector:
         matchLabels:
           os: linux
           arch: arm64
     - bin: bin/kubectl-create-workspace
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-create-workspace-plugin_0.26.1_linux_amd64.tar.gz
-      sha256: 297ca8027abbf2f5f46dfc308d2cd54162be21a465d05f58b2163208f3b4ed78
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-create-workspace-plugin_0.27.0_linux_amd64.tar.gz
+      sha256: 4631e5faab42ed28111d30f38258979ffa7278834d5bbad20687804abbce06b7
       selector:
         matchLabels:
           os: linux
           arch: amd64
     - bin: bin/kubectl-create-workspace
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-create-workspace-plugin_0.26.1_darwin_arm64.tar.gz
-      sha256: b87ec90597fdf0048471aaa00ee2c0ab8014382901476c9bd0a3742c76e82239
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-create-workspace-plugin_0.27.0_darwin_arm64.tar.gz
+      sha256: f58e357a772c781ab4c11bfc7351882a77f6e9abd4b91f89a9a221edd60e73a0
       selector:
         matchLabels:
           os: darwin
           arch: arm64
     - bin: bin/kubectl-create-workspace
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-create-workspace-plugin_0.26.1_darwin_amd64.tar.gz
-      sha256: c0d104f3331664e5d94bb20bba69f4829df5728e95dbe02653912246037aace5
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-create-workspace-plugin_0.27.0_darwin_amd64.tar.gz
+      sha256: 10db2640642a7e76496c5c668797d9d9a13d40faed2fb3c462a93216bf88ca17
       selector:
         matchLabels:
           os: darwin

--- a/plugins/kcp.yaml
+++ b/plugins/kcp.yaml
@@ -4,46 +4,46 @@ kind: Plugin
 metadata:
   name: kcp
 spec:
-  version: v0.26.1
+  version: v0.27.0
   platforms:
     - bin: bin/kubectl-kcp.exe
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-kcp-plugin_0.26.1_windows_arm64.tar.gz
-      sha256: f96f181dac5f13c840b7cf3d56c4130c00cce2182287ce1266c530c90389334c
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-kcp-plugin_0.27.0_windows_arm64.tar.gz
+      sha256: 7d5e3458af3d4d6d9c1df043e6b32d7af7bb463d13dd5c0d718c0ce1edc08d71
       selector:
         matchLabels:
           os: windows
           arch: arm64
     - bin: bin/kubectl-kcp.exe
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-kcp-plugin_0.26.1_windows_amd64.tar.gz
-      sha256: 4cd567c11510259d3d009a121a25bd4c93f1b1431f01050b1cc980a245ef3f5d
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-kcp-plugin_0.27.0_windows_amd64.tar.gz
+      sha256: 0316e73e8760e1f2b0b53675978331806af5e1dfc6bba2e5eb2885f64b3947a9
       selector:
         matchLabels:
           os: windows
           arch: amd64
     - bin: bin/kubectl-kcp
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-kcp-plugin_0.26.1_linux_arm64.tar.gz
-      sha256: 9f2b0867985215926acbd2ad7181076e5ea861d2c37a40e162b91583092d32ff
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-kcp-plugin_0.27.0_linux_arm64.tar.gz
+      sha256: 5b7d92f80358286909f74a1562974deda91479a3ecf482000ffcdc9eb583debc
       selector:
         matchLabels:
           os: linux
           arch: arm64
     - bin: bin/kubectl-kcp
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-kcp-plugin_0.26.1_linux_amd64.tar.gz
-      sha256: 58e427fc1de7fe1c4fec9d8b9aa1ff7472a21c4ffd0bd924b6f409fed44ce4c5
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-kcp-plugin_0.27.0_linux_amd64.tar.gz
+      sha256: e7566272cd83b997e77045dc5b8dd6d2c82dcf668a1bf896f71d08fa486c93a8
       selector:
         matchLabels:
           os: linux
           arch: amd64
     - bin: bin/kubectl-kcp
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-kcp-plugin_0.26.1_darwin_arm64.tar.gz
-      sha256: febd431b33b5e0b00ecfa3acf5f80fb613ce03ae99eb42b777af193467b42faf
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-kcp-plugin_0.27.0_darwin_arm64.tar.gz
+      sha256: ee7e635d5d9f507f4ebe901042fe9461aafd9e82a967735977640c8ff9b16c0d
       selector:
         matchLabels:
           os: darwin
           arch: arm64
     - bin: bin/kubectl-kcp
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-kcp-plugin_0.26.1_darwin_amd64.tar.gz
-      sha256: e72405ab2a043e4e4e46ad0590b2304172dea9a2a8e723bc1362bf1be9979585
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-kcp-plugin_0.27.0_darwin_amd64.tar.gz
+      sha256: ff39ec62fec6d770f700d5606893c9ca626da9547d5f8d29f2cd2f5da61d3f05
       selector:
         matchLabels:
           os: darwin

--- a/plugins/ws.yaml
+++ b/plugins/ws.yaml
@@ -4,46 +4,46 @@ kind: Plugin
 metadata:
   name: ws
 spec:
-  version: v0.26.1
+  version: v0.27.0
   platforms:
     - bin: bin/kubectl-ws.exe
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-ws-plugin_0.26.1_windows_arm64.tar.gz
-      sha256: c292ad1f40b33cbbe786dd66730a307cb6e651afbc8740ba82f23d3da56b610c
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-ws-plugin_0.27.0_windows_arm64.tar.gz
+      sha256: 0ea81bf6f14bc7bb4de376f42b935acd5f8174da4e31d2838804ddca55829651
       selector:
         matchLabels:
           os: windows
           arch: arm64
     - bin: bin/kubectl-ws.exe
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-ws-plugin_0.26.1_windows_amd64.tar.gz
-      sha256: af83a254e102651daa042f29d1cffb03bc066a6a29285ad596a29502f17a5012
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-ws-plugin_0.27.0_windows_amd64.tar.gz
+      sha256: 3649a99839afbc99abb0744dc2b9572f4838b01eb9cf1403982907310acb73c0
       selector:
         matchLabels:
           os: windows
           arch: amd64
     - bin: bin/kubectl-ws
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-ws-plugin_0.26.1_linux_arm64.tar.gz
-      sha256: 3db642a931a40ec574560c5016099bb56fa69220a28286805cb2e024b56886eb
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-ws-plugin_0.27.0_linux_arm64.tar.gz
+      sha256: bbad82fb9b85ebc4bfd46198c05077bee239ef7748c2fcee924494814d01b98e
       selector:
         matchLabels:
           os: linux
           arch: arm64
     - bin: bin/kubectl-ws
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-ws-plugin_0.26.1_linux_amd64.tar.gz
-      sha256: 93f696ac42d77dcfcc5ff4c7a959cfd04dba6a704f9cc8821c3914305cf263b0
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-ws-plugin_0.27.0_linux_amd64.tar.gz
+      sha256: 6ce037b0024858c86f70095d7b0db05898b850cc80ef9c5cadb60511ef05f15f
       selector:
         matchLabels:
           os: linux
           arch: amd64
     - bin: bin/kubectl-ws
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-ws-plugin_0.26.1_darwin_arm64.tar.gz
-      sha256: 5a4719bc088fcfbdc857a0aa5e5b5a3e3a1e74f87a50554ae9142144016d72c9
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-ws-plugin_0.27.0_darwin_arm64.tar.gz
+      sha256: 0d5b634d0fa93bb5c9f5361fb47e5b569cb43de18a41a995fe98a88b0b60966f
       selector:
         matchLabels:
           os: darwin
           arch: arm64
     - bin: bin/kubectl-ws
-      uri: https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kubectl-ws-plugin_0.26.1_darwin_amd64.tar.gz
-      sha256: 973583538eb7de8b352e89c20b53dfbeaf87d3086c37ffef8714e39551913e27
+      uri: https://github.com/kcp-dev/kcp/releases/download/v0.27.0/kubectl-ws-plugin_0.27.0_darwin_amd64.tar.gz
+      sha256: d533b1704921cc2d736e465f209c0cb0dc369a43c34742ca3c9957621de2d70e
       selector:
         matchLabels:
           os: darwin


### PR DESCRIPTION
The goreleaser token for krew-index expired, so here's a manual bump.